### PR TITLE
Fix - Allowed directories and files for publishing the theme

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,9 +2,5 @@
 .vscode-test/**
 .gitignore
 .gitattributes
-src/**
-docs/**
-images/**
 .github/**
-CHANGELOG.md
-README.md
+src/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-08-07
+
+There is not a specific ticket for these changes.
+
+### Fixed
+
+- The `.vscodeignore` file to allow the required files for publishing the theme in the Marketplace.
+
 ## [0.1.0] - 2025-08-07
 
 There is not a specific ticket for these changes.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-theme-for-vscode",
   "displayName": "Material Theme for VSCode",
   "description": "A beautifully crafted Visual Studio Code theme inspired by Material Design.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "license": "MIT",
   "author": "Víctor Hugo Valle Castillo",


### PR DESCRIPTION
## [0.1.1] - 2025-08-07

There is not a specific ticket for these changes.

### Fixed

- The `.vscodeignore` file to allow the required files for publishing the theme in the Marketplace.