### PR TITLE
Feature - Publish the extension to the Open VSX Registry

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -39,10 +39,14 @@ jobs:
           echo "   File size: $(du -h themes/material-theme-for-vscode-dark.json | cut -f1)"
           echo "   Lines: $(wc -l < themes/material-theme-for-vscode-dark.json)"
 
-      # Install vsce
-      - name: Install vsce
-        run: npm i -g @vscode/vsce
+      # Install vsce and ovsx
+      - name: Install vsce and ovsx
+        run: npm i -g @vscode/vsce ovsx
 
       # Publish the extension to the VS Code Marketplace
       - name: Publish to VS Code Marketplace
         run: vsce publish --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+
+      # Publish the extension to the Open VSX Registry
+      - name: Publish to Open VSX Registry
+        run: ovsx publish --pat ${{ secrets.OPENVSX_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-08-13
+
+There is not a specific ticket for these changes.
+
+### Added
+
+- NPM script and Workflow step to publish the extension on the Open VSX Registry.
+
+### Changed
+
+- Removed deprecated NPM script `prebuild`.
+- Updated NPM scripts to publish the extension in multiple Marketplaces/Registries.
+
 ## [0.1.1] - 2025-08-07
 
 There is not a specific ticket for these changes.

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   "homepage": "https://github.com/vihuvac/material-theme-for-vscode",
   "keywords": [
     "vscode",
+    "openvsx",
     "theme",
     "material",
-    "dark",
-    "openvsx"
+    "dark"
   ],
   "engines": {
     "vscode": "^1.60.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "material-theme-for-vscode",
   "displayName": "Material Theme for VSCode",
   "description": "A beautifully crafted Visual Studio Code theme inspired by Material Design.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "license": "MIT",
   "author": "Víctor Hugo Valle Castillo",
@@ -17,7 +17,8 @@
     "vscode",
     "theme",
     "material",
-    "dark"
+    "dark",
+    "openvsx"
   ],
   "engines": {
     "vscode": "^1.60.0"
@@ -29,9 +30,10 @@
     "build": "node --experimental-strip-types src/build.ts",
     "build:deno": "deno run --allow-read --allow-write src/build.ts",
     "dev": "npm run build && echo 'Theme rebuilt - reload VS Code to see changes'",
-    "prebuild": "echo 'Building Material Theme from source files...'",
     "package": "npx vsce package",
-    "publish": "npx vsce publish"
+    "publish:vscode": "npx vsce publish",
+    "publish:openvsx": "npx ovsx publish",
+    "publish:all": "npx vsce publish && npx ovsx publish"
   },
   "contributes": {
     "themes": [


### PR DESCRIPTION
## [0.1.2] - 2025-08-13

There is not a specific ticket for these changes.

### Added

- NPM script and Workflow step to publish the extension on the Open VSX Registry.

### Changed

- Removed deprecated NPM script `prebuild`.
- Updated NPM scripts to publish the extension in multiple Marketplaces/Registries.